### PR TITLE
Allow assumption of Terraform account provisioner role

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -53,6 +53,7 @@ locals {
     data.terraform_remote_state.sharedservices-production.outputs.provisionaccount_role.arn,
     data.terraform_remote_state.sharedservices-staging.outputs.provisionaccount_role.arn,
     data.terraform_remote_state.terraform.outputs.access_terraform_backend_role.arn,
+    data.terraform_remote_state.terraform.outputs.provisionaccount_role.arn,
   ]
 
   prohibited_non_assessment_provision_roles = setsubtract(local.all_non_assessment_provision_roles, local.required_non_assessment_roles)


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the permission to assume the Terraform account provisioner role.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

cisagov/cool-assessment-terraform#132 (specifically https://github.com/cisagov/cool-assessment-terraform/commit/c17b9463539d6dabec4ffd8d52ee787f2ffdce95) made it necessary to assume the Terraform account provisioner role in order to provision assessment environments.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I applied this change successfully and verified that the Terraform account provisioner role was moved from the "Deny" section of the policy to the "Allow" section.  I also confirmed that a user in the assessment provisioner group is now able to successfully run a `terraform apply` in `cool-assessment-terraform` with these updated permissions.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
