### PR TITLE
Add ParameterStoreReadOnly roles

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -47,7 +47,9 @@ locals {
   # See https://github.com/cisagov/cool-assessment-terraform/issues/133.
   required_non_assessment_roles = [
     data.terraform_remote_state.dns_certboto.outputs.provisioncertificatereadroles_role.arn,
+    data.terraform_remote_state.images_parameterstore-production.outputs.parameterstorereadonly_role.arn,
     data.terraform_remote_state.images_parameterstore-production.outputs.provisionparameterstorereadroles_role.arn,
+    data.terraform_remote_state.images_parameterstore-staging.outputs.parameterstorereadonly_role.arn,
     data.terraform_remote_state.images_parameterstore-staging.outputs.provisionparameterstorereadroles_role.arn,
     data.terraform_remote_state.master.outputs.organizationsreadonly_role.arn,
     data.terraform_remote_state.sharedservices-production.outputs.provisionaccount_role.arn,


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds two additional `ParameterStoreReadOnly` roles (production and staging) to the set of roles that assessment provisioners are allowed to assume.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

With the recent changes in https://github.com/cisagov/cool-assessment-terraform/pull/154 (specifically https://github.com/cisagov/cool-assessment-terraform/pull/154/commits/bf36200668404d47aa91a9ad8b8585c96b62ab00), access to these roles is now required for assessment provisioners.  One of the provisioners notified me that today they suddenly started getting an error about not being able to assume the `ParameterStoreReadOnly` role while attempting to apply the Terraform in [`cool-assessment-terraform`](https://github.com/cisagov/cool-assessment-terraform).

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I applied these changes and then verified that an account provisioner was able to successfully apply the code in [`cool-assessment-terraform`](https://github.com/cisagov/cool-assessment-terraform).

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
