### PR TITLE
Allow assumption of start/stop SSM session role

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ No modules.
 | provision\_assessment\_policy\_description | The description to associate with the IAM policy in the Users account that allows the assessment provisioner group to assume all roles needed in order to provision assessment environments. | `string` | `"Allows the assessment provisioner group to assume all roles needed in order to provision assessment environments."` | no |
 | provision\_assessment\_policy\_name | The name of the IAM policy in the Users account that allows the assessment provisioner group to assume all roles needed in order to provision assessment environments. | `string` | `"AssumeProvisionAssessment"` | no |
 | provision\_assessment\_role\_name | The name of the IAM role in assessment accounts that includes all permissions necessary to provision the assessment environment in that account.  If this role does not exist in an account, an assessment environment cannot be provisioned in that account. | `string` | `"ProvisionAccount"` | no |
+| startstopssmsession\_role\_name | The name of the IAM role in assessment accounts that includes all permissions necessary to start and stop an SSM session in that account. | `string` | `"StartStopSSMSession"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 | users | A list containing the usernames of users that exist in the Users account who are allowed to provision assessment environments.  Example: [ "firstname1.lastname1", "firstname2.lastname2" ]. | `list(string)` | n/a | yes |
 

--- a/locals.tf
+++ b/locals.tf
@@ -38,6 +38,9 @@ locals {
   # Create a list of all provision roles in non-assessment accounts.
   all_non_assessment_provision_roles = formatlist("arn:aws:iam::%s:role/%s", local.all_non_assessment_account_ids, var.provision_assessment_role_name)
 
+  # Create a list of all startstopssmsession roles in non-assessment accounts.
+  all_non_assessment_startstopssmsession_roles = formatlist("arn:aws:iam::%s:role/%s", local.all_non_assessment_account_ids, var.startstopssmsession_role_name)
+
   # Assumption of the following non-assessment account roles is required
   # to successfully provision assessment environments.
   # TODO: Determine if it is possible/worthwhile to replace any
@@ -58,5 +61,9 @@ locals {
     data.terraform_remote_state.terraform.outputs.provisionaccount_role.arn,
   ]
 
+  # Create set of prohibited non-assessment account provision roles.
   prohibited_non_assessment_provision_roles = setsubtract(local.all_non_assessment_provision_roles, local.required_non_assessment_roles)
+
+  # Create comprehensive set of prohibited non-assessment account roles.
+  prohibited_non_assessment_roles = setunion(local.prohibited_non_assessment_provision_roles, local.all_non_assessment_startstopssmsession_roles)
 }

--- a/policies.tf
+++ b/policies.tf
@@ -22,6 +22,7 @@ data "aws_iam_policy_document" "provision_assessment" {
 
     resources = [
       "arn:aws:iam::*:role/${var.provision_assessment_role_name}",
+      "arn:aws:iam::*:role/${var.startstopssmsession_role_name}",
     ]
 
     sid = "AllowAssessmentAccountRoles"
@@ -48,7 +49,7 @@ data "aws_iam_policy_document" "provision_assessment" {
 
     effect = "Deny"
 
-    resources = local.prohibited_non_assessment_provision_roles
+    resources = local.prohibited_non_assessment_roles
 
     sid = "DenyNonAssessmentAccountRoles"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,12 @@ variable "provision_assessment_role_name" {
   default     = "ProvisionAccount"
 }
 
+variable "startstopssmsession_role_name" {
+  type        = string
+  description = "The name of the IAM role in assessment accounts that includes all permissions necessary to start and stop an SSM session in that account."
+  default     = "StartStopSSMSession"
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources created."


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds support so that assessment provisioners can assume the role that allows them to start/stop SSM sessions in assessment accounts.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

As part of the assessment environment provisioning process, the provisioner needs to be able to start up a shell on certain instances (e.g. Guacamole).  This PR grants that additional access.

Note that as part of this effort, I added the `AssessmentAccount = "true"` tag to all of our assessment-environment StartStopSSMSession roles (created [here](https://github.com/cisagov/cool-assessment-terraform/blob/develop/ssm_session_role.tf)).

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I worked with one of the assessment environment provisioners and confirmed that they are able to successfully use SSM to open a session to an instance in an assessment account.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

