### PR TITLE
Allow assumption of the Users account provision role

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -58,6 +58,7 @@ locals {
     data.terraform_remote_state.sharedservices-production.outputs.provisionaccount_role.arn,
     data.terraform_remote_state.sharedservices-staging.outputs.provisionaccount_role.arn,
     data.terraform_remote_state.terraform.outputs.provisionaccount_role.arn,
+    data.terraform_remote_state.users.outputs.provisionaccount_role.arn,
   ]
   required_non_assessment_roles_backend = concat(local.required_non_assessment_roles_no_backend, [
     data.terraform_remote_state.terraform.outputs.access_terraform_backend_role.arn,


### PR DESCRIPTION
## 🗣 Description ##

This pull request modified the Terraform code to allow COOL assessment provisioners to also assume the Users account provision role.

See also cisagov/cool-assessment-terraform#254.

## 💭 Motivation and context ##

This is necessary due to the changes in cisagov/cool-assessment-terraform#254.

## 🧪 Testing ##

All automated tests pass.  I also deployed these changes to our COOL Users account and verified as part of the testing for cisagov/cool-assessment-terraform#254 that they function as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.