### PR TITLE
Support new COOL environment structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__
 .terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
+*.tfconfig
 *.tfvars

--- a/README.md
+++ b/README.md
@@ -78,11 +78,9 @@ No modules.
 | [aws_iam_policy_document.provision_assessment_no_backend](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 | [terraform_remote_state.dns_certboto](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.images_parameterstore-production](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.images_parameterstore-staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.images_parameterstore](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.master](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.sharedservices-production](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.sharedservices-staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.sharedservices](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.users](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
@@ -102,6 +100,7 @@ No modules.
 | provision\_assessment\_role\_name | The name of the IAM role in assessment accounts that includes all permissions necessary to provision the assessment environment in that account.  If this role does not exist in an account, an assessment environment cannot be provisioned in that account. | `string` | `"ProvisionAccount"` | no |
 | startstopssmsession\_role\_name | The name of the IAM role in assessment accounts that includes all permissions necessary to start and stop an SSM session in that account. | `string` | `"StartStopSSMSession"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
+| terraform\_state\_bucket | The name of the S3 bucket where Terraform state is stored. | `string` | n/a | yes |
 | users | A map.  The keys are the names of users that exist in the Users account and are to be allowed to provision assessment environments.  The values are maps with a single key, "backend\_access", which is a boolean value indicating whether or not the user should have general Terraform backend access.  Example: {"firstname1.lastname1" = {backend\_access = true}}, {"firstname2.lastname2" = {backend\_access = false}}. | `map(object({ backend_access = bool }))` | n/a | yes |
 
 ## Outputs ##

--- a/backend.tf
+++ b/backend.tf
@@ -1,10 +1,14 @@
 terraform {
   backend "s3" {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-assessment-provisioner-iam/terraform.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-assessment-provisioner-iam/terraform.tfstate"
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -28,11 +28,11 @@ locals {
   caller_user_name = split("/", data.aws_caller_identity.default.arn)[1]
 
   # Get IDs of all non-assessment accounts in the organization, i.e. those
-  # that don't have account names like: "env[:digit:] (.*)"
+  # that don't have account names like: "env[:digit:]+"
   all_non_assessment_account_ids = [
     for account in data.aws_organizations_organization.cool.accounts :
     account.id
-    if length(regexall("^env[[:digit:]]+ \\(.*\\)$", account.name)) == 0
+    if length(regexall("^env[[:digit:]]+", account.name)) == 0
   ]
 
   # Create a list of all provision roles in non-assessment accounts.

--- a/locals.tf
+++ b/locals.tf
@@ -50,13 +50,10 @@ locals {
   # See https://github.com/cisagov/cool-assessment-terraform/issues/133.
   required_non_assessment_roles_no_backend = [
     data.terraform_remote_state.dns_certboto.outputs.provisioncertificatereadroles_role.arn,
-    data.terraform_remote_state.images_parameterstore-production.outputs.parameterstorereadonly_role.arn,
-    data.terraform_remote_state.images_parameterstore-production.outputs.provisionparameterstorereadroles_role.arn,
-    data.terraform_remote_state.images_parameterstore-staging.outputs.parameterstorereadonly_role.arn,
-    data.terraform_remote_state.images_parameterstore-staging.outputs.provisionparameterstorereadroles_role.arn,
+    data.terraform_remote_state.images_parameterstore.outputs.parameterstorereadonly_role.arn,
+    data.terraform_remote_state.images_parameterstore.outputs.provisionparameterstorereadroles_role.arn,
     data.terraform_remote_state.master.outputs.organizationsreadonly_role.arn,
-    data.terraform_remote_state.sharedservices-production.outputs.provisionaccount_role.arn,
-    data.terraform_remote_state.sharedservices-staging.outputs.provisionaccount_role.arn,
+    data.terraform_remote_state.sharedservices.outputs.provisionaccount_role.arn,
     data.terraform_remote_state.terraform.outputs.provisionaccount_role.arn,
     data.terraform_remote_state.users.outputs.provisionaccount_role.arn,
   ]

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -8,54 +8,37 @@ data "terraform_remote_state" "dns_certboto" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-backend"
-    region         = "us-east-1"
+    encrypt        = true
     key            = "cool-dns-certboto/terraform.tfstate"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
   }
 
-  # There is only one environment for this account, so there is
-  # no need to set up "production" and "staging" remote states.
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
-data "terraform_remote_state" "images_parameterstore-production" {
+data "terraform_remote_state" "images_parameterstore" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-images-parameterstore/terraform.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-images-parameterstore/terraform.tfstate"
   }
 
-  workspace = "production"
-}
-
-data "terraform_remote_state" "images_parameterstore-staging" {
-  backend = "s3"
-
-  config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
-    dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-backend"
-    region         = "us-east-1"
-    key            = "cool-images-parameterstore/terraform.tfstate"
-  }
-
-  workspace = "staging"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "master" {
   backend = "s3"
 
   config = {
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "cool-accounts/master.tfstate"
@@ -63,46 +46,29 @@ data "terraform_remote_state" "master" {
     region         = "us-east-1"
   }
 
-  # There is only one environment for this account, so there is
-  # no need to set up "production" and "staging" remote states.
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
-data "terraform_remote_state" "sharedservices-production" {
+data "terraform_remote_state" "sharedservices" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-accounts/shared_services.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-accounts/shared_services.tfstate"
   }
 
-  workspace = "production"
-}
-
-data "terraform_remote_state" "sharedservices-staging" {
-  backend = "s3"
-
-  config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
-    dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-backend"
-    region         = "us-east-1"
-    key            = "cool-accounts/shared_services.tfstate"
-  }
-
-  workspace = "staging"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "terraform" {
   backend = "s3"
 
   config = {
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "cool-accounts/terraform.tfstate"
@@ -110,9 +76,7 @@ data "terraform_remote_state" "terraform" {
     region         = "us-east-1"
   }
 
-  # There is only one environment for this account, so there is
-  # no need to set up "production" and "staging" remote states.
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "users" {
@@ -120,14 +84,12 @@ data "terraform_remote_state" "users" {
 
   config = {
     encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
     key            = "cool-accounts/users.tfstate"
   }
 
-  # There is only one environment for this account, so there is
-  # no need to set up "production" and "staging" remote states.
-  workspace = "production"
+  workspace = terraform.workspace
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,7 @@
 
 variable "terraform_state_bucket" {
   description = "The name of the S3 bucket where Terraform state is stored."
+  nullable    = false
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,11 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
+variable "terraform_state_bucket" {
+  description = "The name of the S3 bucket where Terraform state is stored."
+  type        = string
+}
+
 variable "users" {
   description = "A map.  The keys are the names of users that exist in the Users account and are to be allowed to provision assessment environments.  The values are maps with a single key, \"backend_access\", which is a boolean value indicating whether or not the user should have general Terraform backend access.  Example: {\"firstname1.lastname1\" = {backend_access = true}}, {\"firstname2.lastname2\" = {backend_access = false}}."
   nullable    = false


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR makes updates in support of the switchover from our legacy account/environment scheme (where staging and production accounts exist within the same AWS organization) to our new scheme (where they do not).

Highlights include:
* Removal of hard-coded references to production and staging resources
* Use of [partial backend configurations](https://developer.hashicorp.com/terraform/language/backend#partial-configuration)

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The goal of this PR is to get us closer to our modernized account scheme where there is no more co-mingling of staging and production accounts.  Doing that will result in cleaner code across all COOL-related repositories as well as improved separation of resources across all COOL environments. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully applied this updated Terraform in dev-a, staging-a, and production environments and everything looks as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
